### PR TITLE
In 'RunOnObject' for Mac, added parenthesis to correct Math

### DIFF
--- a/src/ProgressBar.cls
+++ b/src/ProgressBar.cls
@@ -572,7 +572,7 @@ Private Sub RunOnObject(ByRef args() As Variant)
     Dim p As String: p = m_procedure
     Dim v As VbCallType: v = VbMethod
     '
-    Select Case UBound(args) - LBound(args) + 1
+    Select Case UBound(args) - (LBound(args) + 1)
     Case 0: LetSet(m_result) = CallByName(o, p, v)
     Case 1: LetSet(m_result) = CallByName(o, p, v, args(0))
     Case 2: LetSet(m_result) = CallByName(o, p, v, args(0), args(1))


### PR DESCRIPTION
This was erroring out on Mac because this math was producing the wrong result.
For the first variation (Ubound=1, Lbound = 0), we need to evaluate to 0 (zero).
**WAS**    
    `Select Case UBound(args) - LBound(args) + 1` (Equals 2)

**CHANGED TO** 
    `Select Case UBound(args) - (LBound(args) + 1)` (Equals 0)

With this change, runs without error on Mac