### PR TITLE
Update DemoClass.cls

### DIFF
--- a/src/Demo/DemoClass.cls
+++ b/src/Demo/DemoClass.cls
@@ -9,7 +9,7 @@ Attribute VB_PredeclaredId = False
 Attribute VB_Exposed = False
 Option Explicit
 
-Public Function DoWork(ByVal progress As ProgressBar, ByRef stepCount As Long) As Variant
+Public Function DoWork(ByVal progress As ProgressBar, ByRef stepCount As Variant) As Variant
     Dim i As Long
     For i = 1 To stepCount
         progress.Info2 = "Running " & i & " out of " & stepCount


### PR DESCRIPTION
Changing the declared type of 'stepCount' from 'Long' to 'Variant' solves the problem that was occuring on Mac.

@cristianbuse (back to the current version of this code), I'm getting `Error 13 - Type Mismatch` on this line in the `ProgressBar.RunOnObject`:
`    Case 2: LetSet(m_result) = CallByName(o, p, v, args(0), args(1))
`
I thought it might be due to `arg(1)` being evaluated as `Variant/Integer`, but the paramter in the `Demo.DoWork` being defined as **`Long`**, so I tried the following:

1. **(Did not solve the problem)** - Explicitely cast the stepCounts to Long in `Demo.Main` (e.g. from '2000' to 'Clng(2000)')  

2. **(Did not solve the problem)** - Changed `stepCount as Long` to `stepCount as Integer` in the `DemoClass.DoWork` 

 
### Interestingly, the following DID solve the problem:

Changed **`ByRef stepCount As Long`** to be **`ByRef stepCount As Variant`**

This Updated Test Method (in `DemoClass`) with the small change from Long to Variant works on Mac and PC -- tested them both

```    
    Public Function DoWork(ByVal progress As ProgressBar, ByRef stepCount As Variant) As Variant
    Dim i As Long
    For i = 1 To stepCount
        progress.Info2 = "Running " & i & " out of " & stepCount
        progress.Value = i / stepCount
        If progress.WasCancelled Then Exit Function
    Next
    DoWork = True
    End Function
```    
